### PR TITLE
adding double quotes around name value

### DIFF
--- a/tasks/lib/xmllint.coffee
+++ b/tasks/lib/xmllint.coffee
@@ -21,7 +21,7 @@ exports.init = (grunt) ->
 
   buildCommand = (dir) ->
     suffixes = for suffix in config.suffixes
-      "-name *.#{suffix}"
+      "-name \"*.#{suffix}\""
     console.log "suffixes", suffixes
     cmd = "find #{dir}"
     cmd += " #{suffixes.join ' -o '}"

--- a/tasks/lib/xmllint.js
+++ b/tasks/lib/xmllint.js
@@ -33,7 +33,7 @@ Licensed under the BSD license.
         _results = [];
         for (_i = 0, _len = _ref.length; _i < _len; _i++) {
           suffix = _ref[_i];
-          _results.push("-name *." + suffix);
+          _results.push("-name \"*." + suffix + "\"");
         }
         return _results;
       })();


### PR DESCRIPTION
I'm using a OSX Yosemite, and in order to get your lint command to work, I had to surround the `-find arg` with double quotes.  Otherwise, `find` was not able to find the files in the directory mentioned.  This is true when you try to run your command in the terminal.

Didn't work: `find src/main/xquery/_configuration/ALL/ice/ice-forms/ -name *.xml -print0 | xargs -0 -n 1 xmllint`
Worked: `find src/main/xquery/_configuration/ALL/ice/ice-forms/ -name "*.xml" -print0 | xargs -0 -n 1 xmllint`

Are you using linux by any chance?  Does it work fine with no double quotes on Linux?
Once I made these changes to your work, everything worked like a charm.  Thanks for making this, by the way.  It's the only xml linter I could find.
